### PR TITLE
Change cargo-dist archive format from xz to tar.gz

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -15,3 +15,5 @@ ci = "github"
 installers = []
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-unknown-linux-musl", "armv7-unknown-linux-musleabihf", "x86_64-unknown-linux-gnu"]
+# Unix archive format (tar.gz instead of tar.xz)
+unix-archive = "tar.gz"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -15,5 +15,5 @@ ci = "github"
 installers = []
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-unknown-linux-musl", "armv7-unknown-linux-musleabihf", "x86_64-unknown-linux-gnu"]
-# Unix archive format (tar.gz instead of tar.xz)
+# Unix archive format
 unix-archive = "tar.gz"


### PR DESCRIPTION
Updates unix-archive setting in dist-workspace.toml to use tar.gz
compression instead of the default tar.xz format.